### PR TITLE
feat(domains): add broslunas.link to allowed domains

### DIFF
--- a/src/components/CustomDomainRedirectHandler.tsx
+++ b/src/components/CustomDomainRedirectHandler.tsx
@@ -22,7 +22,8 @@ export default function CustomDomainRedirectHandler({ children }: CustomDomainRe
       // Skip if we're already on the main domain or localhost
       if (currentDomain === 'localhost' || 
           currentDomain === '127.0.0.1' || 
-          currentDomain.includes('broslunas.link') || 
+          currentDomain === 'broslunas.link' ||
+          currentDomain === 'www.broslunas.link' ||
           currentDomain.includes('vercel.app') ||
           currentDomain.includes('localhost')) {
         return;

--- a/src/lib/redirect-handler.ts
+++ b/src/lib/redirect-handler.ts
@@ -38,7 +38,10 @@ export async function handleRedirect(
         let domainFilter = {};
 
         // Check if this is a custom domain request
-        if (requestDomain !== process.env.DEFAULT_DOMAIN && requestDomain !== 'localhost:3000') {
+        if (requestDomain !== process.env.DEFAULT_DOMAIN && 
+            requestDomain !== 'localhost:3000' && 
+            requestDomain !== 'broslunas.link' && 
+            requestDomain !== 'www.broslunas.link') {
             customDomain = await CustomDomain.findOne({
                 fullDomain: requestDomain,
                 isVerified: true,
@@ -209,7 +212,8 @@ export async function shouldRedirectToMainDomain(
             requestDomain === 'localhost:3000' ||
             requestDomain === 'localhost' ||
             requestDomain === '127.0.0.1' ||
-            requestDomain.includes('broslunas.link') ||
+            requestDomain === 'broslunas.link' ||
+            requestDomain === 'www.broslunas.link' ||
             requestDomain.includes('vercel.app')) {
             return { success: true };
         }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -23,6 +23,8 @@ const DEFAULT_DOMAINS = [
   'localhost',
   '127.0.0.1:3000',
   '127.0.0.1',
+  'broslunas.link',
+  'www.broslunas.link',
   process.env.DEFAULT_DOMAIN,
   process.env.VERCEL_URL,
   process.env.NEXT_PUBLIC_APP_URL?.replace('https://', '').replace('http://', ''),


### PR DESCRIPTION
Update middleware, redirect handler and component to explicitly include broslunas.link and www.broslunas.link as allowed domains alongside existing localhost and vercel.app domains